### PR TITLE
refactor: Make the API session-centric, allow switching providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Séance provides a unified interface to communicate with different providers lik
 
 ## Installation
 
-You can install Seance using `nimble`:
+You can install Séance using `nimble`:
 
 ```bash
 nimble install seance
@@ -106,26 +106,17 @@ nimble add seance
 Here's a basic example of how to use `seance` in your Nim code:
 
 ```nim
+import seance
 import seance/providers
 
 when isMainModule:
-  # Initialize a provider (e.g., OpenAI)
-  # The API key and model will be loaded from your config.ini or environment variables
-  let openaiProvider = newOpenAIProvider()
+  var sess = newChatSession()
+  let result = sess.chat("Hello, how are you?", provider = OpenAI)
+  echo result.content
 
-  # Send a chat message
-  let response = waitFor openaiProvider.chat("Hello, how are you?")
-  echo "OpenAI Response: ", response
-
-  # Initialize a Gemini provider
-  let geminiProvider = newGeminiProvider()
-  let geminiResponse = waitFor geminiProvider.chat("Tell me a fun fact about Nim programming language.")
-  echo "Gemini Response: ", geminiResponse
-
-  # You can also specify a custom model or API key if needed
-  # let customOpenAIProvider = newOpenAIProvider(model = "gpt-3.5-turbo", apiKey = "sk-your-custom-key")
-  # let customResponse = waitFor customOpenAIProvider.chat("What's the weather like today?")
-  # echo "Custom OpenAI Response: ", customResponse
+  # You can also change the provider mid-session
+  let anotherResult = sess.chat("Translate 'hello' to French", provider = Gemini)
+  echo anotherResult.content
 ```
 
 ## Development

--- a/seance.nimble
+++ b/seance.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.1"
+version       = "0.3.0"
 author        = "Emre Şafak"
 description   = "A CLI tool and library for interacting with various LLMs"
 license       = "MIT"

--- a/src/seance.nim
+++ b/src/seance.nim
@@ -1,3 +1,6 @@
+from seance/session import newChatSession
+export newChatSession
+
 # This is the main entry point for the executable.
 # It uses cligen to dispatch to the correct command implementation.
 import cligen

--- a/src/seance/providers.nim
+++ b/src/seance/providers.nim
@@ -1,12 +1,34 @@
-# This module re-exports all available providers
-# to make them easy to import and use in the main application.
-
-from providers/common import LLMProvider, ChatMessage, MessageRole, ChatResult, chat
+import strutils, tables
+import config
+from providers/common import ChatProvider, ChatMessage, MessageRole, ChatResult, chat
+from config import Config, ProviderConfig
 from providers/anthropic import AnthropicProvider, newAnthropicProvider
 from providers/gemini import GeminiProvider, newGeminiProvider
 from providers/openai import OpenAIProvider, newOpenAIProvider
 
-export LLMProvider, ChatMessage, MessageRole, ChatResult, chat,
+type
+  Provider* = enum
+    OpenAI,
+    Gemini,
+    Anthropic
+
+export ChatProvider, ChatMessage, MessageRole, ChatResult, chat,
        AnthropicProvider, newAnthropicProvider,
        GeminiProvider, newGeminiProvider,
-       OpenAIProvider, newOpenAIProvider
+       OpenAIProvider, newOpenAIProvider,
+       Provider
+
+proc getProvider*(provider: Provider, config: Config): ChatProvider =
+  ## Factory function to create a provider instance from its name.
+  let providerName = $provider
+  if not config.providers.hasKey(providerName):
+    raise newException(ConfigError, "Provider not found in config: " & providerName)
+
+  let providerConf = config.providers[providerName]
+  if providerConf.key.len == 0:
+    raise newException(ConfigError, "API key for provider '" & providerName & "' is not set.")
+
+  case provider
+  of Anthropic: return newAnthropicProvider(providerConf)
+  of Gemini: return newGeminiProvider(providerConf)
+  of OpenAI: return newOpenAIProvider(providerConf)

--- a/src/seance/providers/common.nim
+++ b/src/seance/providers/common.nim
@@ -9,12 +9,12 @@ type
     content*: string
     model*: string
 
-  LLMProvider* = ref object of RootObj
+  ChatProvider* = ref object of RootObj
 
   Session* = object
     messages*: seq[ChatMessage]
 
-method chat*(provider: LLMProvider, messages: seq[ChatMessage]): ChatResult {.base.} =
+method chat*(provider: ChatProvider, messages: seq[ChatMessage], model: string = ""): ChatResult {.base.} =
   raise newException(Defect, "chat() not implemented for this provider")
 
 proc `$`*(role: MessageRole): string =

--- a/src/seance/providers/gemini.nim
+++ b/src/seance/providers/gemini.nim
@@ -29,7 +29,7 @@ const
   ApiUrlBase = "https://generativelanguage.googleapis.com/v1beta/models/"
 
 type
-  GeminiProvider* = ref object of LLMProvider
+  GeminiProvider* = ref object of ChatProvider
     conf*: ProviderConfig
     postRequestHandler: proc(url: string, body: string, headers: HttpHeaders): Response
 
@@ -52,13 +52,13 @@ proc toGeminiContents(messages: seq[ChatMessage]): seq[GeminiContent] =
     let role = if msg.role == assistant: "model" else: "user"
     result.add(GeminiContent(role: role, parts: @[GeminiContentPart(text: msg.content)]))
 
-method chat*(provider: GeminiProvider, messages: seq[ChatMessage]): ChatResult =
+method chat*(provider: GeminiProvider, messages: seq[ChatMessage], model: string = ""): ChatResult =
   ## Implementation of the chat method for Gemini.
-  var model = provider.conf.model
-  if model.len == 0:
-    model = DefaultGeminiModel
+  let modelToUse = if model.len > 0: model else: provider.conf.model
+  if modelToUse.len == 0:
+    raise newException(ValueError, "Model not specified via argument or config")
 
-  let apiUrl = ApiUrlBase & model & ":generateContent?key=" & provider.conf.key
+  let apiUrl = ApiUrlBase & modelToUse & ":generateContent?key=" & provider.conf.key
 
   let requestHeaders = newHttpHeaders([("Content-Type", "application/json")])
 

--- a/src/seance/session.nim
+++ b/src/seance/session.nim
@@ -1,5 +1,7 @@
 import std/json
 import std/os
+import providers
+import config
 import providers/common
 
 var sessionDir* = getHomeDir() / ".config" / "seance" / "sessions"
@@ -29,3 +31,16 @@ proc saveSession*(sessionId: string, session: Session) =
   let sessionFile = getSessionFilePath(sessionId)
   let data = %session
   writeFile(sessionFile, pretty(data))
+
+proc newChatSession*(): Session =
+  return Session(messages: @[])
+
+import providers
+
+proc chat*(session: var Session, query: string, provider: Provider): ChatResult =
+  let config = loadConfig()
+  let chatProvider = getProvider(provider, config)
+  session.messages.add(ChatMessage(role: user, content: query))
+  let result = chatProvider.chat(session.messages)
+  session.messages.add(ChatMessage(role: assistant, content: result.content, model: result.model))
+  return result

--- a/tests/t_providers_anthropic.nim
+++ b/tests/t_providers_anthropic.nim
@@ -42,7 +42,7 @@ suite "Anthropic Provider":
     )
 
     let provider = newAnthropicProvider(defaultConf, mockPostRequestHandler)
-    let result = provider.chat(testMessages)
+    let result = provider.chat(testMessages, model = DefaultAnthropicModel)
 
     check capturedUrl == "https://api.anthropic.com/v1/messages"
     check capturedHeaders["x-api-key"] == defaultConf.key

--- a/tests/t_providers_gemini.nim
+++ b/tests/t_providers_gemini.nim
@@ -57,7 +57,7 @@ suite "Gemini Provider":
     )
 
     let provider = newGeminiProvider(defaultConf, mockPostRequestHandler)
-    let result = provider.chat(testMessages)
+    let result = provider.chat(testMessages, model = DefaultGeminiModel)
 
     let expectedUrl = "https://generativelanguage.googleapis.com/v1beta/models/" & DefaultGeminiModel & ":generateContent?key=" & defaultConf.key
     check capturedUrl == expectedUrl

--- a/tests/t_providers_openai.nim
+++ b/tests/t_providers_openai.nim
@@ -70,7 +70,7 @@ suite "OpenAI Provider":
     # Initialize the provider with our custom mock POST request handler
     let provider = newOpenAIProvider(defaultConf, mockPostRequestHandler)
 
-    let result = provider.chat(testMessages)
+    let result = provider.chat(testMessages, model = DefaultOpenaiModel)
 
     # Assertions on the captured request details
     check capturedUrl == "https://api.openai.com/v1/chat/completions"
@@ -114,7 +114,7 @@ suite "OpenAI Provider":
     let provider = newOpenAIProvider(defaultConf, mockPostRequestHandler)
 
     expect IOError:
-      discard provider.chat(testMessages)
+      discard provider.chat(testMessages, model = "gpt-4")
 
   test "chat method raises ValueError on empty choices array in successful response":
     mockHttpResponse = Response(
@@ -125,4 +125,4 @@ suite "OpenAI Provider":
     let provider = newOpenAIProvider(defaultConf, mockPostRequestHandler)
 
     expect ValueError:
-      discard provider.chat(testMessages)
+      discard provider.chat(testMessages, model = "gpt-4")


### PR DESCRIPTION
* Refactored the chat interface to use a `Provider` enum instead of string names.
* Updated `commands.nim` to accept `Provider` enum for specifying the LLM provider.
* Modified `LLMProvider` to `ChatProvider` in `providers/common.nim` for clarity.
* Introduced a `getProvider` function in `providers.nim` for provider instantiation.
* Updated `chat` methods in provider implementations to accept an optional `model` argument.
* Modified example usage in `README.md` to reflect the new `Provider` enum and simplified chat calls.
* Added `newChatSession` procedure to `seance.nim` and `session.nim`.
* Updated tests to pass the model explicitly to the `chat` method.