### PR TITLE
feat: Add getProvider convenience function and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,26 +97,43 @@ By default, Séance will automatically create a session for each conversation. Y
 
 You can also import `seance` into your Nim projects to programmatically interact with LLMs.
 
-First, add `seance` to your project's dependencies:
+### With a Configuration File
 
-```bash
-nimble add seance
-```
-
-Here's a basic example of how to use `seance` in your Nim code:
+If you have a `config.ini` file at `~/.config/seance/config.ini`, `seance` will automatically find and use it when you call `loadConfig()`.
 
 ```nim
 import seance
-import seance/providers
 
-when isMainModule:
-  var sess = newChatSession()
-  let result = sess.chat("Hello, how are you?", provider = OpenAI)
-  echo result.content
+# 1. Get a provider instance (config is loaded automatically)
+let provider = getProvider(OpenAI)
 
-  # You can also change the provider mid-session
-  let anotherResult = sess.chat("Translate 'hello' to French", provider = Gemini)
-  echo anotherResult.content
+# 2. Create a session and chat
+var sess = newChatSession()
+let result = sess.chat("What is the capital of Nimland?", provider)
+echo result.content
+```
+
+### Manual Configuration
+
+For more direct control or to avoid using a config file, you can instantiate a provider manually. This is ideal for library use where you manage keys and settings yourself.
+
+```nim
+import seance
+import seance/providers # This imports ProviderConfig and new*Provider functions
+
+# 1. Manually create a provider configuration
+let providerConf = ProviderConfig(
+  key: "your_secret_api_key",
+  model: "gpt-4o"
+)
+
+# 2. Instantiate the provider directly
+let provider = newOpenAIProvider(providerConf)
+
+# 3. Create a session and chat
+var sess = newChatSession()
+let result = sess.chat("What is the capital of Nimland?", provider)
+echo result.content
 ```
 
 ## Development

--- a/seance.nimble
+++ b/seance.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.0"
+version       = "0.3.1"
 author        = "Emre Şafak"
 description   = "A CLI tool and library for interacting with various LLMs"
 license       = "MIT"

--- a/src/seance.nim
+++ b/src/seance.nim
@@ -1,5 +1,6 @@
 from seance/session import newChatSession
-export newChatSession
+from seance/providers import getProvider
+export newChatSession, getProvider
 
 # This is the main entry point for the executable.
 # It uses cligen to dispatch to the correct command implementation.

--- a/src/seance/config.nim
+++ b/src/seance/config.nim
@@ -13,23 +13,22 @@ type
 
   ConfigError* = object of CatchableError
 
-var configPath: string
+var customConfigPath: string
 
 proc setConfigPath*(path: string) =
-  configPath = path
+  customConfigPath = path
 
 proc getConfigPath*(): string =
-  ## Returns the standard path for the config file.
-  if configPath.len > 0:
-    return configPath
-  let home = getHomeDir()
-  let configDir = home / ".config" / "seance"
-  return configDir / "config.ini"
+  if customConfigPath.len > 0:
+    return customConfigPath
+  else:
+    return getHomeDir() / ".config" / "seance" / "config.ini"
 
-proc loadConfig*(path: string = ""): Config =
+proc loadConfig*(): Config =
   ## Loads and parses the INI config file.
+  ## It automatically finds the config file in the default location.
   ## Raises ConfigError on validation errors.
-  let configPath = if path.len > 0: path else: getConfigPath()
+  let configPath = getConfigPath()
 
   if not fileExists(configPath):
     raise newException(ConfigError, "Config file not found at: " & configPath &

--- a/src/seance/providers.nim
+++ b/src/seance/providers.nim
@@ -32,3 +32,8 @@ proc getProvider*(provider: Provider, config: Config): ChatProvider =
   of Anthropic: return newAnthropicProvider(providerConf)
   of Gemini: return newGeminiProvider(providerConf)
   of OpenAI: return newOpenAIProvider(providerConf)
+
+proc getProvider*(provider: Provider): ChatProvider =
+  ## Convenience function that loads the default config and returns a provider.
+  let config = loadConfig()
+  return getProvider(provider, config)

--- a/src/seance/session.nim
+++ b/src/seance/session.nim
@@ -1,7 +1,6 @@
 import std/json
 import std/os
 import providers
-import config
 import providers/common
 
 var sessionDir* = getHomeDir() / ".config" / "seance" / "sessions"
@@ -37,10 +36,8 @@ proc newChatSession*(): Session =
 
 import providers
 
-proc chat*(session: var Session, query: string, provider: Provider): ChatResult =
-  let config = loadConfig()
-  let chatProvider = getProvider(provider, config)
+proc chat*(session: var Session, query: string, provider: ChatProvider): ChatResult =
   session.messages.add(ChatMessage(role: user, content: query))
-  result = chatProvider.chat(session.messages)
+  result = provider.chat(session.messages)
   session.messages.add(ChatMessage(role: assistant, content: result.content, model: result.model))
   return result

--- a/tests/t_config_loading.nim
+++ b/tests/t_config_loading.nim
@@ -1,7 +1,6 @@
 import std/tables
-import os, strutils
+import os
 import unittest
-import std/parsecfg
 
 import seance/config
 
@@ -30,7 +29,8 @@ key = gem-abcdef
 # model is optional
 """
     writeFile(testConfigPath, content)
-    let config = config.loadConfig(testConfigPath)
+    setConfigPath(testConfigPath)
+    let config = config.loadConfig()
     check config.defaultProvider == "openai"
     check config.autoSession == false
     check config.providers.len == 2
@@ -40,14 +40,16 @@ key = gem-abcdef
     check config.providers["gemini"].model == ""
 
   test "raises ConfigError for missing file":
+    setConfigPath("non_existent_file.ini")
     expect ConfigError:
-      discard config.loadConfig("non_existent_file.ini")
+      discard config.loadConfig()
 
   test "raises ConfigError for missing key":
     let content = "[openai]\nmodel = gpt-4o"
     writeFile(testConfigPath, content)
+    setConfigPath(testConfigPath)
     expect ConfigError:
-      discard config.loadConfig(testConfigPath)
+      discard config.loadConfig()
 
   test "raises ConfigError for parsing error":
     let content = """
@@ -55,8 +57,9 @@ key = gem-abcdef
 key = bad-ini
 """
     writeFile(testConfigPath, content)
+    setConfigPath(testConfigPath)
     try:
-      discard config.loadConfig(testConfigPath)
+      discard config.loadConfig()
       fail()
     except ConfigError as e:
       check(e.msg.len > 0)

--- a/tests/t_sessions.nim
+++ b/tests/t_sessions.nim
@@ -4,6 +4,12 @@ import times
 import seance/session
 import seance/commands
 import seance/config
+import seance/providers
+import seance/providers/common
+
+type MockProvider = ref object of ChatProvider
+method chat(provider: MockProvider, messages: seq[ChatMessage], model: string = ""): ChatResult =
+  return ChatResult(content: "bar", model: "gpt-4")
 
 suite "Session Management":
   var oldSessionDir: string
@@ -15,7 +21,7 @@ suite "Session Management":
     let configDir = "./test_config"
     createDir(configDir)
     let configFile = configDir / "config.ini"
-    writeFile(configFile, "[seance]\ndefault_provider=openai\n[openai]\nkey=test")
+    writeFile(configFile, "[seance]\ndefault_provider=openai\n[openai]\nkey=test\nmodel=gpt-4")
     setConfigPath(configFile)
 
   teardown:
@@ -54,4 +60,22 @@ suite "Session Management":
 
     # Clean up the corrupt file manually
     removeFile(corruptSessionFile)
+
+  test "Chatting in a session":
+    # 1. Create a mock ChatProvider
+    let mockProvider = MockProvider()
+
+    # 2. Create a session and chat
+    var sess = newChatSession()
+    let result = sess.chat("foo", mockProvider)
+
+    # 3. Assertions
+    check(sess.messages.len == 2)
+    check(sess.messages[0].role == user)
+    check(sess.messages[0].content == "foo")
+    check(sess.messages[1].role == assistant)
+    check(sess.messages[1].content == "bar")
+    check(sess.messages[1].model == "gpt-4")
+    check(result.content == "bar")
+    check(result.model == "gpt-4")
 


### PR DESCRIPTION
* Add `getProvider` function to `providers.nim` for easier provider instantiation.
* Export `getProvider` from the main `seance` module.
* Update `README.md` with examples for both configuration file and manual provider setup.
* Modify `t_sessions.nim` to include a test for chatting in a session using a mock provider.
* Refactor `session.nim` to accept a `ChatProvider` directly in the `chat` proc.
* Update `seance.nimble` to version 0.3.1.
* Adjust `loadConfig` in `config.nim` to automatically find the config file.
* Update tests in `t_config_loading.nim` to use `setConfigPath` for better isolation.