### PR TITLE
refactor: Rename `chat` to `dispatchChat` to avoid a collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,15 @@ By default, Séance will automatically create a session for each conversation. Y
   seance prune
 
   # Prune sessions older than 30 days
+  ```bash
   seance prune --days 30
+  ```
+
+- **Disabling Session for a Single Chat**: To prevent a session from being loaded or saved for a specific chat, use the `--no_session` flag:
+
+  ```bash
+  seance chat "This chat should not be saved." --no_session
+  ```
   ```
 
 ## Using as a Library

--- a/seance.nimble
+++ b/seance.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.1"
+version       = "0.3.2"
 author        = "Emre Şafak"
 description   = "A CLI tool and library for interacting with various LLMs"
 license       = "MIT"

--- a/src/seance.nim
+++ b/src/seance.nim
@@ -12,11 +12,11 @@ dispatchMulti(
     commands.chat,
     help = {
       "prompt": "The prompt to send to the LLM. Can be combined with stdin input.",
-      "provider": "The name of the provider to use (e.g., 'openai'). Defaults to the 'default_provider' in your config.",
       "model": "The specific model to use (overrides config).",
       "systemPrompt": "An optional system prompt to guide the model's response.",
       "verbose": "Set verbosity level (0=info, 1=debug, 2=all).",
-      "dryRun": "If true, prints the final prompt instead of sending it to the LLM."
+      "dryRun": "If true, prints the final prompt instead of sending it to the LLM.",
+      "noSession": "If true, no session will be loaded or saved."
     },
   ],
   [commands.list],

--- a/src/seance/providers.nim
+++ b/src/seance/providers.nim
@@ -1,6 +1,6 @@
-import  tables
+import  tables, strutils
 import config
-from providers/common import ChatProvider, ChatMessage, MessageRole, ChatResult, chat
+from providers/common import ChatProvider, ChatMessage, MessageRole, ChatResult, dispatchChat
 from config import Config, ProviderConfig
 from providers/anthropic import AnthropicProvider, newAnthropicProvider
 from providers/gemini import GeminiProvider, newGeminiProvider
@@ -12,17 +12,24 @@ type
     Gemini,
     Anthropic
 
-export ChatProvider, ChatMessage, MessageRole, ChatResult, chat,
+export ChatProvider, ChatMessage, MessageRole, ChatResult, dispatchChat,
        AnthropicProvider, newAnthropicProvider,
        GeminiProvider, newGeminiProvider,
        OpenAIProvider, newOpenAIProvider,
        Provider
 
+proc parseProvider*(providerName: string): Provider =
+  case providerName.normalize():
+  of "openai": result = OpenAI
+  of "gemini": result = Gemini
+  of "anthropic": result = Anthropic
+  else: raise newException(ConfigError, "Unknown provider: " & providerName)
+
 proc getProvider*(provider: Provider, config: Config): ChatProvider =
   ## Factory function to create a provider instance from its name.
-  let providerName = $provider
+  let providerName = ($provider).normalize()
   if not config.providers.hasKey(providerName):
-    raise newException(ConfigError, "Provider not found in config: " & providerName)
+    raise newException(ConfigError, "Provider '" & providerName & "' not found in config.")
 
   let providerConf = config.providers[providerName]
   if providerConf.key.len == 0:

--- a/src/seance/providers/anthropic.nim
+++ b/src/seance/providers/anthropic.nim
@@ -44,7 +44,7 @@ proc newAnthropicProvider*(conf: ProviderConfig, postRequestHandler: proc(
                   postRequestHandler
   return AnthropicProvider(conf: conf, postRequestHandler: handler)
 
-method chat*(provider: AnthropicProvider, messages: seq[ChatMessage], model: string = ""): ChatResult =
+method dispatchChat*(provider: AnthropicProvider, messages: seq[ChatMessage], model: string = ""): ChatResult =
   ## Implementation of the chat method for Anthropic.
   let requestHeaders = newHttpHeaders([
     ("x-api-key", provider.conf.key),

--- a/src/seance/providers/common.nim
+++ b/src/seance/providers/common.nim
@@ -11,10 +11,9 @@ type
 
   ChatProvider* = ref object of RootObj
 
-  Session* = object
-    messages*: seq[ChatMessage]
+  
 
-method chat*(provider: ChatProvider, messages: seq[ChatMessage], model: string = ""): ChatResult {.base.} =
+method dispatchChat*(provider: ChatProvider, messages: seq[ChatMessage], model: string = ""): ChatResult {.base.} =
   raise newException(Defect, "chat() not implemented for this provider")
 
 proc `$`*(role: MessageRole): string =

--- a/src/seance/providers/gemini.nim
+++ b/src/seance/providers/gemini.nim
@@ -52,7 +52,7 @@ proc toGeminiContents(messages: seq[ChatMessage]): seq[GeminiContent] =
     let role = if msg.role == assistant: "model" else: "user"
     result.add(GeminiContent(role: role, parts: @[GeminiContentPart(text: msg.content)]))
 
-method chat*(provider: GeminiProvider, messages: seq[ChatMessage], model: string = ""): ChatResult =
+method dispatchChat*(provider: GeminiProvider, messages: seq[ChatMessage], model: string = ""): ChatResult =
   ## Implementation of the chat method for Gemini.
   let modelToUse = if model.len > 0: model else: provider.conf.model
   if modelToUse.len == 0:

--- a/src/seance/providers/openai.nim
+++ b/src/seance/providers/openai.nim
@@ -51,7 +51,7 @@ proc newOpenAIProvider*(conf: ProviderConfig, postRequestHandler: proc(
                   postRequestHandler # Use the provided custom handler
   return OpenAIProvider(conf: conf, postRequestHandler: handler)
 
-method chat*(provider: OpenAIProvider, messages: seq[ChatMessage],
+method dispatchChat*(provider: OpenAIProvider, messages: seq[ChatMessage],
     model: string = ""): ChatResult =
   ## Implementation of the chat method for OpenAI using a live API call
   # Set authentication headers (these are still specific to the provider)

--- a/src/seance/session.nim
+++ b/src/seance/session.nim
@@ -3,6 +3,10 @@ import std/os
 import providers
 import providers/common
 
+type
+  Session* = object
+    messages*: seq[ChatMessage]
+
 var sessionDir* = getHomeDir() / ".config" / "seance" / "sessions"
 
 proc getSessionFilePath*(sessionId: string): string =
@@ -34,10 +38,8 @@ proc saveSession*(sessionId: string, session: Session) =
 proc newChatSession*(): Session =
   return Session(messages: @[])
 
-import providers
-
-proc chat*(session: var Session, query: string, provider: ChatProvider): ChatResult =
+proc chat*(session: var Session, query: string, provider: ChatProvider, model: string = ""): ChatResult =
   session.messages.add(ChatMessage(role: user, content: query))
-  result = provider.chat(session.messages)
+  result = dispatchChat(provider, session.messages, model)
   session.messages.add(ChatMessage(role: assistant, content: result.content, model: result.model))
   return result

--- a/tests/t_providers_anthropic.nim
+++ b/tests/t_providers_anthropic.nim
@@ -42,7 +42,7 @@ suite "Anthropic Provider":
     )
 
     let provider = newAnthropicProvider(defaultConf, mockPostRequestHandler)
-    let result = provider.chat(testMessages, model = DefaultAnthropicModel)
+    let result = provider.dispatchChat(testMessages, model = DefaultAnthropicModel)
 
     check capturedUrl == "https://api.anthropic.com/v1/messages"
     check capturedHeaders["x-api-key"] == defaultConf.key

--- a/tests/t_providers_gemini.nim
+++ b/tests/t_providers_gemini.nim
@@ -57,7 +57,7 @@ suite "Gemini Provider":
     )
 
     let provider = newGeminiProvider(defaultConf, mockPostRequestHandler)
-    let result = provider.chat(testMessages, model = DefaultGeminiModel)
+    let result = provider.dispatchChat(testMessages, model = DefaultGeminiModel)
 
     let expectedUrl = "https://generativelanguage.googleapis.com/v1beta/models/" & DefaultGeminiModel & ":generateContent?key=" & defaultConf.key
     check capturedUrl == expectedUrl

--- a/tests/t_providers_openai.nim
+++ b/tests/t_providers_openai.nim
@@ -70,7 +70,7 @@ suite "OpenAI Provider":
     # Initialize the provider with our custom mock POST request handler
     let provider = newOpenAIProvider(defaultConf, mockPostRequestHandler)
 
-    let result = provider.chat(testMessages, model = DefaultOpenaiModel)
+    let result = provider.dispatchChat(testMessages, model = DefaultOpenaiModel)
 
     # Assertions on the captured request details
     check capturedUrl == "https://api.openai.com/v1/chat/completions"
@@ -99,7 +99,7 @@ suite "OpenAI Provider":
       bodyStream: newStringStream("""{"choices": [{"message": {"content": "Another mocked response for custom model."}}]}""")
     )
 
-    let result = customModelProvider.chat(testMessages)
+    let result = customModelProvider.dispatchChat(testMessages)
 
     let requestJson = parseJson(capturedRequestBody) # Use the renamed variable here
     check requestJson["model"].getStr() == "my-custom-model-v1" # Verify custom model usage
@@ -114,7 +114,7 @@ suite "OpenAI Provider":
     let provider = newOpenAIProvider(defaultConf, mockPostRequestHandler)
 
     expect IOError:
-      discard provider.chat(testMessages, model = "gpt-4")
+      discard provider.dispatchChat(testMessages, model = "gpt-4")
 
   test "chat method raises ValueError on empty choices array in successful response":
     mockHttpResponse = Response(
@@ -125,4 +125,4 @@ suite "OpenAI Provider":
     let provider = newOpenAIProvider(defaultConf, mockPostRequestHandler)
 
     expect ValueError:
-      discard provider.chat(testMessages, model = "gpt-4")
+      discard provider.dispatchChat(testMessages, model = "gpt-4")

--- a/tests/t_sessions.nim
+++ b/tests/t_sessions.nim
@@ -8,7 +8,7 @@ import seance/providers
 import seance/providers/common
 
 type MockProvider = ref object of ChatProvider
-method chat(provider: MockProvider, messages: seq[ChatMessage], model: string = ""): ChatResult =
+method dispatchChat(provider: MockProvider, messages: seq[ChatMessage], model: string = ""): ChatResult =
   return ChatResult(content: "bar", model: "gpt-4")
 
 suite "Session Management":


### PR DESCRIPTION
*   Renamed the `chat` method to `dispatchChat` in `providers/common.nim` to avoid collisions in libraries
*   Updated all provider implementations (OpenAI, Gemini, Anthropic) to use `dispatchChat`.
*   Modified `tests/t_providers_openai.nim`, `tests/t_providers_anthropic.nim`, and `tests/t_providers_gemini.nim` to call `dispatchChat`.
*   Adjusted `seance/session.nim` to use `dispatchChat` within its `chat` procedure.
*   Updated `seance/commands.nim` to use `dispatchChat` when interacting with providers.
*   Added a `noSession` flag to the `chat` command in `seance/commands.nim` and updated its help text in `seance.nim`.
*   Added documentation for the `noSession` flag in `README.md`.
*   Introduced `parseProvider` proc in `seance/providers.nim` for better provider name handling.
*   Updated `seance/providers.nim` to export `dispatchChat`.
*   Modified `tests/t_sessions.nim` to use `dispatchChat` in its mock provider.