### PR TITLE
fix: don't shadow other CLI utilities when imported

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -67,10 +67,10 @@ All configuration keys use consistent naming and MUST be documented.
 Use GrabNim to install nim and nimble, paying attention to its output for instructions on setting the $PATH:
 
 ```bash
-wget -q0 - https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh | sh 
+wget -q https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh | sh 
 ```
 
-It might be something like this:
+Delete this file after configuring the PATH. It might be something like this:
 
 ```bash
 export PATH="$HOME/.local/share/grabnim/current/bin:$PATH"

--- a/seance.nimble
+++ b/seance.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.4"
+version       = "0.3.5"
 author        = "Emre Şafak"
 description   = "A CLI tool and library for interacting with various LLMs"
 license       = "MIT"

--- a/src/seance.nim
+++ b/src/seance.nim
@@ -20,23 +20,24 @@ proc argParse[T](dst: var Option[T], dfl: Option[T],
 proc argHelp[T](dfl: Option[T], a: var ArgcvtParams): seq[string] =
   @[argKeys(a), $T, (if dfl.isSome: $dfl.get else: "see config file")]
 
-# This is the main entry point for the executable.
-# It uses cligen to dispatch to the correct command implementation.
-dispatchMulti(
-  [
-    commands.chat,
-    help = {
-      "prompt": "Prompt to send to the LLM. Can be combined with stdin input.",
-      "provider": "LLM provider to use: OpenAI, Anthropic, or Gemini.",
-      "session": "UUID session ID.",
-      "model": "LLM model to use.",
-      "systemPrompt": "System prompt to guide the model's response.",
-      "verbose": "Verbosity level (0=info, 1=debug, 2=all).",
-      "dryRun": "If true, prints the final prompt instead of sending it to the LLM.",
-      "noSession": "If true, no session will be loaded or saved."
-    },
-  ],
-  [commands.list],
-  [commands.prune, help = {"days": "The number of days to keep sessions."}],
-  [commands.version],
-)
+when isMainModule:
+  # This is the main entry point for the executable.
+  # It uses cligen to dispatch to the correct command implementation.
+  dispatchMulti(
+    [
+      commands.chat,
+      help = {
+        "prompt": "Prompt to send to the LLM. Can be combined with stdin input.",
+        "provider": "LLM provider to use: OpenAI, Anthropic, or Gemini.",
+        "session": "UUID session ID.",
+        "model": "LLM model to use.",
+        "systemPrompt": "System prompt to guide the model's response.",
+        "verbose": "Verbosity level (0=info, 1=debug, 2=all).",
+        "dryRun": "If true, prints the final prompt instead of sending it to the LLM.",
+        "noSession": "If true, no session will be loaded or saved."
+      },
+    ],
+    [commands.list],
+    [commands.prune, help = {"days": "The number of days to keep sessions."}],
+    [commands.version],
+  )


### PR DESCRIPTION
* Update the package version to 0.3.5 in seance.nimble.
* Refine AGENT.md with clearer instructions for GrabNim installation.
* Add a note to delete GrabNim install script after PATH configuration.
* Correct the wget flag from -q0 to -q in AGENT.md.
* Enclose main executable entry point in `when isMainModule:` block in src/seance.nim.